### PR TITLE
fix: update Django version to 3.1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-asgiref==3.2.3
-Django==3.0.4
+asgiref==3.4.1
+Django==3.1.14
 django-bootstrap4==1.1.1
 django-crispy-forms==1.9.0
 pkg-resources==0.0.0


### PR DESCRIPTION
This update required fixing vulnerabilities in the older version 3.0.4.

Package asgiref is also updated to version 3.4.1.